### PR TITLE
Update example site config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,8 +1,8 @@
 baseURL = "https://www.example.com"
 languageCode = "en-us"
 title = "My Digital Garden"
-theme = "hugo-digital-garden-theme"
-themesdir = "../../"
+theme = "digital-garden"
+themesdir = "./themes"
 copyright = "Nigalya Ponya ©"
 
 


### PR DESCRIPTION
In the [setup docs](https://themes.gohugo.io/themes/hugo-digital-garden-theme/#getting-started), the submodule is named `digital-garden`. The themes is directly under the root folder.
This config change should help people set up a little bit faster :)

I made the suggestion in Github. It has also suggested a newline change at the end - feel free to ignore that.