### PR TITLE
Add rel attribute to social media footer links

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         </div>
         <div class="col-sm-6 d-flex flex-row-reverse">
             {{ range .Site.Params.Social }}
-            <a class="footer-social px-2" href="{{ .link }}" target="_blank"><i class="{{ .icon }}"></i></a>
+            <a class="footer-social px-2" {{ with .rel }} rel="{{ . }}" {{ end }} href="{{ .link }}" target="_blank"><i class="{{ .icon }}"></i></a>
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
Just a quick patch to better support `rel="me"` links.  Thanks for your work developing the theme.