### PR TITLE
Config parameter for dark mode

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -3,6 +3,18 @@
 <script src="/js/isotope.pkgd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/masonry-layout@4.2.2/dist/masonry.pkgd.min.js" integrity="sha384-GNFwBvfVxBkLMJpYMOABq3c+d3KnQxudP/mGPkzpZSTYykLBNsZEnG2D9G/X/+7D" crossorigin="anonymous" async></script>
 <script src="/js/dark.js"></script>
+<script>
+// set the default theme
+{{ if .Site.Params.darkModeDefault }}
+
+var savedTheme = localStorage.getItem("dark-mode-storage") || "{{ .Site.Params.darkModeDefault }}" 
+setTheme(savedTheme);
+
+{{ else }}
+var savedTheme = localStorage.getItem("dark-mode-storage") || "light" 
+setTheme(savedTheme);
+{{ end }}
+</script>
 <script src="/js/isotope.js"></script>
 <script src="/js/mermaid.min.js"></script>
 <script>mermaid.initialize({ startOnLoad: true, securityLevel: 'loose'});</script>

--- a/static/js/dark.js
+++ b/static/js/dark.js
@@ -19,7 +19,3 @@ function setTheme(mode) {
         toggle.className = "btn fas fa-moon";
     }
 }
-
-// the default theme is light
-var savedTheme = localStorage.getItem("dark-mode-storage") || "light";
-setTheme(savedTheme);


### PR DESCRIPTION
Resolves https://github.com/paulmartins/hugo-digital-garden-theme/issues/11

So as discussed on the issue, I added a parameter to set the initial state for dark or light mode.  I did some testing locally with private browser windows to clear the local storage and it seems to work.  I also spent a while trying to add some kind of validation to ensure the parameter is set to something sensible, but honestly the Go Templates language defeated me.  If you've got some pointers on how to do validation in templates, I'd be happy to take another pass at it.  That said, it seems to degrade gracefully (to light mode) if the parameter is set to something bogus.

Thanks again for pointing me in the right direction on the issue.